### PR TITLE
Encoding selection dropdown added (for UTF8 Encoding)

### DIFF
--- a/ReportSync.Designer.cs
+++ b/ReportSync.Designer.cs
@@ -271,6 +271,28 @@
             this.bottomPanel.Size = new System.Drawing.Size(758, 36);
             this.bottomPanel.TabIndex = 22;
             // 
+            // lblEncoding
+            // 
+            this.lblEncoding.AutoSize = true;
+            this.lblEncoding.Location = new System.Drawing.Point(607, 9);
+            this.lblEncoding.Name = "lblEncoding";
+            this.lblEncoding.Size = new System.Drawing.Size(55, 13);
+            this.lblEncoding.TabIndex = 23;
+            this.lblEncoding.Text = "Encoding:";
+            // 
+            // cbEncoding
+            // 
+            this.cbEncoding.FormattingEnabled = true;
+            this.cbEncoding.Items.AddRange(new object[] {
+            "Default",
+            "UTF8"});
+            this.cbEncoding.Location = new System.Drawing.Point(668, 6);
+            this.cbEncoding.Name = "cbEncoding";
+            this.cbEncoding.Size = new System.Drawing.Size(75, 21);
+            this.cbEncoding.TabIndex = 22;
+            this.cbEncoding.Text = "Default";
+            this.cbEncoding.SelectedIndexChanged += new System.EventHandler(this.cbEncoding_SelectedIndexChanged);
+            // 
             // btnUpload
             // 
             this.btnUpload.Location = new System.Drawing.Point(378, 6);

--- a/ReportSync.Designer.cs
+++ b/ReportSync.Designer.cs
@@ -51,6 +51,8 @@
             this.bottomStrip = new System.Windows.Forms.StatusStrip();
             this.currentStatus = new System.Windows.Forms.ToolStripStatusLabel();
             this.bottomPanel = new System.Windows.Forms.Panel();
+            this.lblEncoding = new System.Windows.Forms.Label();
+            this.cbEncoding = new System.Windows.Forms.ComboBox();
             this.btnUpload = new System.Windows.Forms.Button();
             this.txtLocalPath = new System.Windows.Forms.TextBox();
             this.lblDest = new System.Windows.Forms.Label();
@@ -256,6 +258,8 @@
             // 
             this.bottomPanel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.bottomPanel.Controls.Add(this.lblEncoding);
+            this.bottomPanel.Controls.Add(this.cbEncoding);
             this.bottomPanel.Controls.Add(this.btnUpload);
             this.bottomPanel.Controls.Add(this.txtLocalPath);
             this.bottomPanel.Controls.Add(this.lblDest);
@@ -835,6 +839,8 @@
         private System.Windows.Forms.ToolStripStatusLabel currentStatus;
         private System.Windows.Forms.Label lbSourceStatus;
         private System.Windows.Forms.Label lbDestStatus;
+        private System.Windows.Forms.ComboBox cbEncoding;
+        private System.Windows.Forms.Label lblEncoding;
     }
 }
 

--- a/ReportSync.cs
+++ b/ReportSync.cs
@@ -24,6 +24,8 @@ namespace ReportSync
         private ReportingServicesMgmt _destServicesMgmt;
         private ReportingServicesMgmt _sourceServicesMgmt;
 
+        private string _selectedEncoding = "Default";
+
         private string _pathOnDisk;
 
         private string _uploadPath = RootFolder;
@@ -115,6 +117,10 @@ namespace ReportSync
                 var report = new XmlDocument();
                 report.Load(file);
                 var reportDef = Encoding.Default.GetBytes(report.OuterXml);
+                if (_selectedEncoding.Equals("UTF8"))
+                {
+                    reportDef = Encoding.UTF8.GetBytes(report.OuterXml);
+                }
                 if (!_existingPaths.Contains(reportPath))
                 {
                     EnsureDestDir(reportPath);
@@ -625,5 +631,21 @@ namespace ReportSync
         {
             tbSourceUser.Enabled = tbSourcePassword.Enabled = !cbSourceIntegratedAuth.Checked;
         }
+
+        private void cbEncoding_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            ComboBox comboBox = (ComboBox) sender;
+            string selectedEncoding = (string)comboBox.SelectedItem;
+            if (!String.IsNullOrEmpty(selectedEncoding))
+            {
+                _selectedEncoding = selectedEncoding;
+            }
+            else
+            {
+                _selectedEncoding = "Default";
+            }
+            
+        }
+
     }
 }


### PR DESCRIPTION
While uploading rdl files with special characters i saw this
Error-Message: The Report Definition [...] contain Content that is not well-formed...
=> Dropdown for Encoding selection was added to solve this